### PR TITLE
fix version constraint

### DIFF
--- a/examples/custom_instance/custom_instance.tf
+++ b/examples/custom_instance/custom_instance.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     contabo = {
       source = "contabo/contabo"
-      version = "v0.1.15"
+      version = ">= 0.1.15"
     }
   }
 }

--- a/examples/main.tf.example
+++ b/examples/main.tf.example
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     contabo = {
       source = "contabo/contabo"
-      version = "v0.1.15"
+      version = ">= 0.1.15"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     contabo = {
       source = "contabo/contabo"
-      version = "v0.1.15"
+      version = ">= 0.1.15"
     }
   }
 }

--- a/examples/use_environment_variables/use_environment_variables.tf
+++ b/examples/use_environment_variables/use_environment_variables.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     contabo = {
       source = "contabo/contabo"
-      version = "v0.1.15"
+      version = ">= 0.1.15"
     }
   }
 }


### PR DESCRIPTION
"v0.1.15" is not a valid version constraint at least in the latest version of terraform

````
Initializing the backend...
╷
│ Error: Invalid version constraint
│ 
│   on main.tf line 3, in terraform:
│    3:     contabo = {
│    4:       source  = "contabo/contabo"
│    5:       version = "v0.0.15"
│    6:     }
│ 
│ Incorrect version constraint syntax: a "v" prefix should not be used.
╵
``` 