### PR TITLE
feat: image wait for download, reupload if changed + existing instance import

### DIFF
--- a/contabo/handleErrors.go
+++ b/contabo/handleErrors.go
@@ -63,3 +63,13 @@ func MultipleDataObjectsError(
 		Detail:   "The API response for a specific object contained multiple objects.",
 	})
 }
+
+func HandleDownloadErrors(
+	diags diag.Diagnostics,
+) diag.Diagnostics {
+	return append(diags, diag.Diagnostic{
+		Severity: diag.Error,
+		Summary:  "Download error, check the image url availability and retry",
+		Detail:   "Download error, check the image url availability and retry",
+	})
+}

--- a/contabo/handleErrors.go
+++ b/contabo/handleErrors.go
@@ -69,7 +69,7 @@ func HandleDownloadErrors(
 ) diag.Diagnostics {
 	return append(diags, diag.Diagnostic{
 		Severity: diag.Error,
-		Summary:  "Download error, check the image url availability and retry",
-		Detail:   "Download error, check the image url availability and retry",
+		Summary:  "Download error, check the url availability and retry",
+		Detail:   "Download error, check the url availability and retry",
 	})
 }

--- a/contabo/resource_image.go
+++ b/contabo/resource_image.go
@@ -77,12 +77,6 @@ func resourceImage() *schema.Resource {
 				Computed:    true,
 				Description: "Downloading status of the image (`downloading`, `downloaded` or `error`).",
 			},
-			"archive_on_update": {
-				Type:        schema.TypeBool,
-				Default:     true,
-				Optional:    true,
-				Description: "When iso url changes, the image will be kept in storage",
-			},
 			"error_message": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -159,8 +153,6 @@ func resourceImageRead(ctx context.Context, d *schema.ResourceData, m interface{
 		XRequestId(uuid.NewV4().String()).
 		Execute()
 
-	pollImageDownloaded(diags, client, ctx, imageId)
-
 	image, diag := pollImageDownloaded(diags, client, ctx, imageId)
 
 	if err != nil || image == nil {
@@ -195,17 +187,6 @@ func resourceImageUpdate(ctx context.Context, d *schema.ResourceData, m interfac
 		newDescription := d.Get("description").(string)
 		updateImageRequest.Description = &newDescription
 		anyChange = true
-	}
-
-	if d.HasChange("image_url") {
-
-		if !d.Get("archive_on_update").(bool) {
-			resourceImageDelete(ctx, d, m)
-		}
-
-		diags := resourceImageCreate(ctx, d, m)
-
-		return diags
 	}
 
 	if anyChange {

--- a/contabo/resource_image.go
+++ b/contabo/resource_image.go
@@ -71,6 +71,12 @@ func resourceImage() *schema.Resource {
 				Computed:    true,
 				Description: "Downloading status of the image (`downloading`, `downloaded` or `error`).",
 			},
+			"remove_on_update": {
+				Type:        schema.TypeBool,
+				Default:     false,
+				Optional:    true,
+				Description: "When url changes, the image will be removed before re-downloaded.",
+			},
 			"error_message": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -186,7 +192,10 @@ func resourceImageUpdate(ctx context.Context, d *schema.ResourceData, m interfac
 	}
 
 	if d.HasChange("image_url") {
-		resourceImageDelete(ctx, d, m)
+
+		if d.Get("remove_on_update").(bool) {
+			resourceImageDelete(ctx, d, m)
+		}
 
 		return resourceImageCreate(ctx, d, m)
 	}

--- a/contabo/resource_instance.go
+++ b/contabo/resource_instance.go
@@ -25,6 +25,7 @@ func resourceInstance() *schema.Resource {
 			"id": {
 				Type:        schema.TypeString,
 				Computed:    true,
+				Optional:    true,
 				Description: "The identifier of the compute instance. Use it to manage it!",
 			},
 			"last_updated": {
@@ -261,6 +262,14 @@ func resourceInstance() *schema.Resource {
 func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	client := m.(*openapi.APIClient)
+
+	id := d.Get("id").(string)
+
+	if id != "" {
+		d.SetId(id)
+
+		return resourceInstanceRead(ctx, d, m)
+	}
 
 	createInstanceRequest := openapi.NewCreateInstanceRequestWithDefaults()
 

--- a/contabo/resource_instance.go
+++ b/contabo/resource_instance.go
@@ -25,8 +25,13 @@ func resourceInstance() *schema.Resource {
 			"id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Optional:    true,
 				Description: "The identifier of the compute instance. Use it to manage it!",
+			},
+			"existing_instance_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Optional:    true,
+				Description: "The identifier of the existing compute instance. (override id)",
 			},
 			"last_updated": {
 				Type:        schema.TypeString,
@@ -263,12 +268,12 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, m inter
 	var diags diag.Diagnostics
 	client := m.(*openapi.APIClient)
 
-	id := d.Get("id").(string)
+	extstingId := d.Get("existing_instance_id").(string)
 
-	if id != "" {
-		d.SetId(id)
+	if extstingId != "" {
+		d.SetId(extstingId)
 
-		return resourceInstanceRead(ctx, d, m)
+		return resourceInstanceUpdate(ctx, d, m)
 	}
 
 	createInstanceRequest := openapi.NewCreateInstanceRequestWithDefaults()

--- a/contabo/resource_instance.go
+++ b/contabo/resource_instance.go
@@ -26,6 +26,7 @@ func resourceInstance() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The identifier of the compute instance. Use it to manage it!",
+				
 			},
 			"existing_instance_id": {
 				Type:        schema.TypeString,
@@ -275,6 +276,8 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 		return resourceInstanceUpdate(ctx, d, m)
 	}
+
+	panic("zizou")
 
 	createInstanceRequest := openapi.NewCreateInstanceRequestWithDefaults()
 

--- a/contabo/resource_instance.go
+++ b/contabo/resource_instance.go
@@ -277,8 +277,6 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, m inter
 		return resourceInstanceUpdate(ctx, d, m)
 	}
 
-	panic("zizou")
-
 	createInstanceRequest := openapi.NewCreateInstanceRequestWithDefaults()
 
 	displayName := d.Get("display_name").(string)


### PR DESCRIPTION
Context : Fix #18 / #14 

Other test available over my release of this provider : https://registry.terraform.io/providers/loic-roux-404/contabo/latest

My test setup : (+ Followed readme for local dev setup)

```tf
variable "ubuntu_release_info" {
  type = object({
    name            = string
    version         = string
    iso_version_tag = string
    url             = string
    format          = string
  })
  default = {
    name            = "jammy"
    version         = "22.04.2"
    iso_version_tag = "ubuntu-jammy-fb3e35e"
    url             = "https://github.com:443/loic-roux-404/k3s-paas/releases/download"
    format          = "qcow2"
  }
}

variable "contabo_instance" {
  type = string
}

locals {
  iso_version_file = "ubuntu-${var.ubuntu_release_info.name}-${var.ubuntu_release_info.version}.${var.ubuntu_release_info.format}"
  image_url = "${var.ubuntu_release_info.url}/${var.ubuntu_release_info.iso_version_tag}/${local.iso_version_file}"
}

resource "contabo_image" "paas_instance_qcow2" {
  name        = var.ubuntu_release_info.name
  image_url   = local.image_url
  os_type     = "Linux"
  version     = var.ubuntu_release_info.iso_version_tag
  description = "generated PaaS vm image with packer"
}

resource "contabo_instance" "paas_instance" {
  existing_instance_id = var.contabo_instance

  display_name = "ubuntu-k3s-paas"
  image_id     = contabo_image.paas_instance_qcow2.id
}
```

My tests : 

- [x] Image update when using new field `existing_instance_id`
- [x] Create image working as usual when no `existing_instance_id` is provided
- [x] Image wait for download 
- [x] Image replace when url changes

I can't run `make test-acc` for your cases because i've already lost too much money with this provider design.