### PR TITLE
Replace the calls to the deprecated io/ioutil package with calls to io and os packages

### DIFF
--- a/client/oauth2.go
+++ b/client/oauth2.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -25,7 +24,7 @@ func BearerHttpClient(
 ) (*http.Client, error) {
 	ctx := context.Background()
 	configuration := &oauth2.Config{
-		ClientID: clientId,
+		ClientID:     clientId,
 		ClientSecret: clientSecret,
 		Endpoint: oauth2.Endpoint{
 			TokenURL: authUrl,
@@ -34,7 +33,6 @@ func BearerHttpClient(
 
 	// check if token has been cached
 	token, err := RestoreTokenFromCache()
-
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +84,7 @@ func RestoreTokenFromCache() (*oauth2.Token, error) {
 		return nil, err
 	}
 
-	serializedToken, err := ioutil.ReadFile(*tokenCacheFileName)
+	serializedToken, err := os.ReadFile(*tokenCacheFileName)
 	if err != nil {
 		return nil, nil
 	}

--- a/contabo/handleErrors.go
+++ b/contabo/handleErrors.go
@@ -11,7 +11,7 @@ import (
 )
 
 type ApiError struct {
-	StatusCode uint16 `json:"statusCode`
+	StatusCode uint16 `json:"statusCode"`
 	Message    string `json:"message"`
 }
 

--- a/contabo/handleErrors.go
+++ b/contabo/handleErrors.go
@@ -3,7 +3,7 @@ package contabo
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 
@@ -23,9 +23,7 @@ func HandleResponseErrors(
 	var responseBody []byte
 	var err error
 
-	if httpResp != nil {
-		responseBody, err = ioutil.ReadAll(httpResp.Body)
-	} else {
+	if httpResp == nil {
 		return append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unexpected API error, no http response",
@@ -33,6 +31,7 @@ func HandleResponseErrors(
 		})
 	}
 
+	responseBody, err = io.ReadAll(httpResp.Body)
 	if err != nil {
 		log.Panic("Error while parsing response error")
 	}

--- a/contabo/oauth2Client/cacheToken.go
+++ b/contabo/oauth2Client/cacheToken.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -34,7 +33,7 @@ func cacheToken(token *oauth2.Token) {
 
 func RestoreTokenFromCache() *oauth2.Token {
 	tokenCacheFileName := getCacheFile()
-	serializedToken, err := ioutil.ReadFile(tokenCacheFileName)
+	serializedToken, err := os.ReadFile(tokenCacheFileName)
 	if err != nil {
 		return nil
 	}

--- a/contabo/oauth2Client/getToken.go
+++ b/contabo/oauth2Client/getToken.go
@@ -2,7 +2,7 @@ package oauth2Client
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -15,7 +15,6 @@ func GetJwtToken(
 	username string,
 	password *string,
 ) {
-
 	strings.NewReader(`asd {{ apiUrl }}`)
 
 	urlEncodedUsername := url.QueryEscape(username)
@@ -25,7 +24,6 @@ func GetJwtToken(
 
 	client := &http.Client{}
 	req, err := http.NewRequest("POST", authUrl, payload)
-
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -39,7 +37,7 @@ func GetJwtToken(
 	}
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/contabo/provider.go
+++ b/contabo/provider.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -192,7 +192,7 @@ func GetJwtToken(
 	}
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return jwtToken, diag.FromErr(err)
 	}

--- a/contabo/provider.go
+++ b/contabo/provider.go
@@ -20,37 +20,37 @@ var userId string
 func Provider() *schema.Provider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
-			"api": &schema.Schema{
+			"api": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CNTB_API", "https://api.contabo.com"),
 				Description: "The api endpoint is https://api.contabo.com.",
 			},
-			"oauth2_token_url": &schema.Schema{
+			"oauth2_token_url": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CNTB_OAUTH2_TOKEN_URL", "https://auth.contabo.com/auth/realms/contabo/protocol/openid-connect/token"),
 				Description: "The oauth2 token url is https://auth.contabo.com/auth/realms/contabo/protocol/openid-connect/token.",
 			},
-			"oauth2_client_id": &schema.Schema{
+			"oauth2_client_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CNTB_OAUTH2_CLIENT_ID", nil),
 				Description: "Your oauth2 client id can be found in the [Customer Control Panel](https://new.contabo.com/account/security) under the menu item account secret.",
 			},
-			"oauth2_client_secret": &schema.Schema{
+			"oauth2_client_secret": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CNTB_OAUTH2_CLIENT_SECRET", nil),
 				Description: "Your oauth2 client secret can be found in the [Customer Control Panel](https://new.contabo.com/account/security) under the menu item account secret.",
 			},
-			"oauth2_user": &schema.Schema{
+			"oauth2_user": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CNTB_OAUTH2_USER", nil),
 				Description: "API User (your email address to login to the [Customer Control Panel](https://new.contabo.com/account/security) under the menu item account secret.",
 			},
-			"oauth2_pass": &schema.Schema{
+			"oauth2_pass": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CNTB_OAUTH2_PASS", nil),


### PR DESCRIPTION
This is just a slight refactoring - `io/ioutil` was deprecated in go 1.16, and looking at `go.mod` this repo uses go 1.17 (sidenote: is there a good reason for not upgrading to go 1.21?).

By the way, [ba48a77](https://github.com/contabo/terraform-provider-contabo/pull/24/commits/ba48a774ec70042fb72d1cf02a1ab5194ee9c84e) fixes api errors showing up as having the status code of `0`.