### PR TITLE
Fix firewall state mapping: use correct schema keys and include action

### DIFF
--- a/contabo/resource_firewall.go
+++ b/contabo/resource_firewall.go
@@ -558,9 +558,9 @@ func AddFirewallToData(
 
 	for _, instanceStatus := range firewall.InstanceStatus {
 		newStatus := make(map[string]interface{})
-		newStatus["instanceId"] = instanceStatus.InstanceId
+		newStatus["instance_id"] = instanceStatus.InstanceId
 		newStatus["status"] = instanceStatus.Status
-		newStatus["errorMessage"] = instanceStatus.ErrorMessage
+		newStatus["error_message"] = instanceStatus.ErrorMessage
 
 		instancesStatus = append(instancesStatus, newStatus)
 	}
@@ -587,6 +587,7 @@ func buildFirewallRules(rulesResponse *openapi.Rules) []interface{} {
 			rule["protocol"] = ruleInbound.Protocol
 			rule["dest_ports"] = ruleInbound.DestPorts
 			rule["status"] = ruleInbound.Status
+			rule["action"] = ruleInbound.Action
 
 			var srcCidrs []interface{}
 			srcCidrMap := make(map[string]interface{})


### PR DESCRIPTION
Fix firewall state mapping: use correct schema keys and include action

- Use snake_case keys (instance_id, error_message) matching the schema instead of camelCase (instanceId, errorMessage) for instance status                                                                                                                                                                                                                                            
- Include the action field when building firewall rules from API response 

Fixes #52 