### PR TITLE
Preserve configured user data during reinstall

### DIFF
--- a/contabo/resource_instance.go
+++ b/contabo/resource_instance.go
@@ -200,7 +200,6 @@ func resourceInstance() *schema.Resource {
 						},
 					},
 				},
-
 			},
 			"error_message": {
 				Type:        schema.TypeString,
@@ -478,12 +477,7 @@ func reinstall(d *schema.ResourceData, client *openapi.APIClient, ctx context.Co
 		}
 	}
 
-	if d.HasChange("user_data") {
-		userData := d.Get("user_data").(string)
-		if userData != "" {
-			patchInstanceRequest.UserData = &userData
-		}
-	}
+	applyReinstallUserData(d, patchInstanceRequest)
 
 	if d.HasChange("default_user") {
 		defaultUser := d.Get("default_user").(string)
@@ -510,6 +504,15 @@ func reinstall(d *schema.ResourceData, client *openapi.APIClient, ctx context.Co
 	}
 	d.SetId(strconv.Itoa(int(res.Data[0].InstanceId)))
 	return diags
+}
+
+func applyReinstallUserData(d *schema.ResourceData, request *openapi.ReinstallInstanceRequest) {
+	userData, ok := d.GetOk("user_data")
+	if !ok || userData.(string) == "" {
+		return
+	}
+	value := userData.(string)
+	request.UserData = &value
 }
 
 func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/contabo/resource_instance_test.go
+++ b/contabo/resource_instance_test.go
@@ -6,12 +6,28 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"contabo.com/openapi"
 )
 
 var creationDisplayName = (uuid.New()).String()
 var updatedDisplayName = (uuid.New()).String()
 var anotherUpdatedDisplayName = (uuid.New()).String()
+
+func TestReinstallPreservesConfiguredUserData(t *testing.T) {
+	data := schema.TestResourceDataRaw(t, resourceInstance().Schema, map[string]interface{}{
+		"user_data": "#cloud-config\nwrite_files: []\n",
+	})
+	request := openapi.NewReinstallInstanceRequestWithDefaults()
+
+	applyReinstallUserData(data, request)
+
+	if request.UserData == nil || *request.UserData != "#cloud-config\nwrite_files: []\n" {
+		t.Fatalf("reinstall user data = %v", request.UserData)
+	}
+}
 
 func TestAccContaboInstanceBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
## Summary

Always send configured `user_data` when any field triggers an instance reinstall, including an image-only update.

Previously, `user_data` was added to the reinstall request only when that attribute itself changed. An image update therefore reinstalled custom images with provider-default cloud-init data and silently dropped the declared bootstrap payload.

## Test

Adds a focused unit test for reinstall request construction. The repository generates its ignored `openapi/` client during CI, so the package test cannot run from a plain source checkout without that generation step.